### PR TITLE
fix build. Cast to DCstring.

### DIFF
--- a/dyncall/dyncall_callf.c
+++ b/dyncall/dyncall_callf.c
@@ -72,22 +72,22 @@ void dcVCallF(DCCallVM* vm, DCValue* result, DCpointer funcptr, const DCsigchar*
   dcArgF_impl(vm, &ptr, args);
 
   switch(*ptr) {
-    case DC_SIGCHAR_VOID:                   dcCallVoid         (vm,funcptr); break;
-    case DC_SIGCHAR_BOOL:       result->B = dcCallBool         (vm,funcptr); break;
-    case DC_SIGCHAR_CHAR:       result->c = dcCallChar         (vm,funcptr); break;
-    case DC_SIGCHAR_UCHAR:      result->C = (DCuchar)dcCallChar(vm,funcptr); break;
-    case DC_SIGCHAR_SHORT:      result->s = dcCallShort        (vm,funcptr); break;
-    case DC_SIGCHAR_USHORT:     result->S = dcCallShort        (vm,funcptr); break;
-    case DC_SIGCHAR_INT:        result->i = dcCallInt          (vm,funcptr); break;
-    case DC_SIGCHAR_UINT:       result->I = dcCallInt          (vm,funcptr); break;
-    case DC_SIGCHAR_LONG:       result->j = dcCallLong         (vm,funcptr); break;
-    case DC_SIGCHAR_ULONG:      result->J = dcCallLong         (vm,funcptr); break;
-    case DC_SIGCHAR_LONGLONG:   result->l = dcCallLongLong     (vm,funcptr); break;
-    case DC_SIGCHAR_ULONGLONG:  result->L = dcCallLongLong     (vm,funcptr); break;
-    case DC_SIGCHAR_FLOAT:      result->f = dcCallFloat        (vm,funcptr); break;
-    case DC_SIGCHAR_DOUBLE:     result->d = dcCallDouble       (vm,funcptr); break;
-    case DC_SIGCHAR_POINTER:    result->p = dcCallPointer      (vm,funcptr); break;
-    case DC_SIGCHAR_STRING:     result->Z = dcCallPointer      (vm,funcptr); break;
+    case DC_SIGCHAR_VOID:                   dcCallVoid             (vm,funcptr); break;
+    case DC_SIGCHAR_BOOL:       result->B = dcCallBool             (vm,funcptr); break;
+    case DC_SIGCHAR_CHAR:       result->c = dcCallChar             (vm,funcptr); break;
+    case DC_SIGCHAR_UCHAR:      result->C = (DCuchar)dcCallChar    (vm,funcptr); break;
+    case DC_SIGCHAR_SHORT:      result->s = dcCallShort            (vm,funcptr); break;
+    case DC_SIGCHAR_USHORT:     result->S = dcCallShort            (vm,funcptr); break;
+    case DC_SIGCHAR_INT:        result->i = dcCallInt              (vm,funcptr); break;
+    case DC_SIGCHAR_UINT:       result->I = dcCallInt              (vm,funcptr); break;
+    case DC_SIGCHAR_LONG:       result->j = dcCallLong             (vm,funcptr); break;
+    case DC_SIGCHAR_ULONG:      result->J = dcCallLong             (vm,funcptr); break;
+    case DC_SIGCHAR_LONGLONG:   result->l = dcCallLongLong         (vm,funcptr); break;
+    case DC_SIGCHAR_ULONGLONG:  result->L = dcCallLongLong         (vm,funcptr); break;
+    case DC_SIGCHAR_FLOAT:      result->f = dcCallFloat            (vm,funcptr); break;
+    case DC_SIGCHAR_DOUBLE:     result->d = dcCallDouble           (vm,funcptr); break;
+    case DC_SIGCHAR_POINTER:    result->p = dcCallPointer          (vm,funcptr); break;
+    case DC_SIGCHAR_STRING:     result->Z = (DCstring)dcCallPointer(vm,funcptr); break;
   }
 }
 


### PR DESCRIPTION
```
building dyncall...
Writing following configuration to ConfigVars:

Host OS:             windows
Target OS:           windows
Target Architecture: x64
Compiler:            gcc
Assembler:           as
Build configuration: release
Install prefix:      C:\dev\MoarVM\3rdparty\dyncall\install_windows_x64_gcc_release
Build prefix:        C:\dev\MoarVM\3rdparty\dyncall\build_out\windows_x64_gcc_release
dyncall_callf.c: In function 'void dcVCallF(DCCallVM*, DCValue*, DCpointer, const DCsigchar*, va_list)':
dyncall_callf.c:90:75: error: invalid conversion from 'DCpointer {aka void*}' to 'DCstring {aka const char*}' [-fpermissive]
     case DC_SIGCHAR_STRING:     result->Z = dcCallPointer      (vm,funcptr); break;
                                                                           ^
gmake[3]: *** [dyncall_callf.o] Error 1
gmake[2]: *** [all] Error 2
gmake[1]: *** [mingw32] Error 2
makefile:591: recipe for target '3rdparty\dyncall\dyncall\libdyncall_s.a' failed
gmake: *** [3rdparty\dyncall\dyncall\libdyncall_s.a] Error 2
```
