### PR TITLE
dyncall: add 10.6 Rosetta case to configure

### DIFF
--- a/configure
+++ b/configure
@@ -123,7 +123,7 @@ case ${TARGET:=`uname`} in
           ARCHS="-arch i386 -arch x86_64 -arch ppc"
           ;;
         10.6.*)                             # == snow leopard (10.6.*)
-          ARCHS="-arch i386 -arch x86_64"   # no more ppc
+          ARCHS="-arch i386 -arch x86_64 -arch ppc" # ppc supported in Rosetta
           ;;
         10.[789].*|10.1[0123].*|10.1[0123]) # >= lion (10.7.*), <= high sierra (10.13.*)
           ARCHS="-arch x86_64 -arch i386"


### PR DESCRIPTION
`ppc` _is_ supported in 10.6.x. All versions of 10.6.x on Intel allow installing Rosetta and building & running `ppc` binaries. Besides that, developer versions of 10.6 exist that run on `ppc` natively.

P. S. In fact, in the original repo there is a case for `ppc` on 10.6, but somehow it got “lost in translation”, it seems. See: https://github.com/zhuomingliang/dyncall/blob/master/configure